### PR TITLE
Added variable declaration doc update

### DIFF
--- a/query.md
+++ b/query.md
@@ -13,10 +13,7 @@ Entities supported so far are,
 - `method_declaraion` : Represents a method declaration.
 - `class_declaration` : Represents a class declaration.
 - `method_invocation` : Represents a method invocation.
-
-### Planned Entities
-
-- `variable_declaration` : Represents a variable declaration. (Not implemented yet)
+- `variable_declaration` : Represents a variable declaration.
 
 ### Supported Attributes
 
@@ -27,6 +24,9 @@ Entities supported so far are,
 - `argumentname` : Represents the argument names of the entity.
 - `superclass` : Represents the superclass of the entity. (Applicable only for class_declaration)
 - `interface` : Represents the interfaces implemented by the entity. (Applicable only for class_declaration)
+- `variabledatatype` : Represents the data type of the variable. (Applicable only for variable_declaration)
+- `variablevalue` : Represents the value of the variable. (Applicable only for variable_declaration)
+- `scope` : Represents the scope of the variable (example: local, field). (Applicable only for variable_declaration)
 
 ## Query Syntax
 


### PR DESCRIPTION
`pathfinder` now supports `variable_declaration` entity.

- Additionally supports attribute `variabledatatype`, `variablevalue`, `scope`, `name`, `modifier`

example:

1. `variable_declaration` query example:

```bash
Path-Finder Query Console: 
>FIND variable_declaration WHERE variabledatatype = 'int'
Executing query: FIND variable_declaration WHERE variabledatatype = 'int' AND scope = 'local'
------Query Results------
int id = item.getItemId();
int number;
int width = displaymetrics.widthPixels;
-------------------
```