### PR TITLE
Feature: Routine `has_access` ensures entity is being accessed 

### DIFF
--- a/query.md
+++ b/query.md
@@ -28,6 +28,10 @@ Entities supported so far are,
 - `variablevalue` : Represents the value of the variable. (Applicable only for variable_declaration)
 - `scope` : Represents the scope of the variable (example: local, field). (Applicable only for variable_declaration)
 
+### Supported Routines
+
+- `has_access` : Represents the routine to check if the entity is being accessed based on scope.
+
 ## Query Syntax
 
 The query syntax is simple and easy to use. The syntax is inspired by SQL and is designed to be simple and easy to use.


### PR DESCRIPTION
New feature 🚀 

`has_access` routine helps to identify entities that are being accessed from the code. For example, 

```java
public void isExample( ) {
  int i = 0;   // i is declared 
  i++;  // i is being accessed
  int k = 1;  // j is declared but not accessed
}
```

```bash
$ Path-Finder console:
> FIND variable_declaration WHERE has_access = 'false' AND scope = 'local'
Result:
int k = 1;
--------------
```

For now, `has_access` works additionally with `local` scope. In future, It would be supported for global access and read|write access too.